### PR TITLE
Add Iceberg File Support with Time Travel Functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",
+        "icebird": "^0.3.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.364.0",
         "next-themes": "^0.4.6",
@@ -4850,6 +4851,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5046,6 +5053,54 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/hyparquet": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.13.1.tgz",
+      "integrity": "sha512-xzUYyfqtIZypo5I1F2HXgnX5J4axKooVZj5GW58kUevfqsmnccZQ3mt+ByYE1MuX9v2pcYVZg48WW1hnO6ypSw==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "license": "MIT",
+      "dependencies": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
+    "node_modules/hyparquet-writer": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/hyparquet-writer/-/hyparquet-writer-0.3.5.tgz",
+      "integrity": "sha512-7Ugi9J/Fia0rz+o+6aoKj82ZGmI0QJ4LO6hyexBZBDUl57i+qVyGz2vJZYQqG82vF/tpTmG3bISgxBnPhJhEKg==",
+      "license": "MIT",
+      "dependencies": {
+        "hyparquet": "1.12.1"
+      }
+    },
+    "node_modules/hyparquet-writer/node_modules/hyparquet": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.12.1.tgz",
+      "integrity": "sha512-M525R8zlfVhz7k9NZr0yd9Tef50NEwYaBDqvLf0CmA/iwk9dHLtIKQvLpJds88Z2SgZVgUWAfR3PN5NJ1tDB8A==",
+      "license": "MIT"
+    },
+    "node_modules/hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
+      "license": "MIT"
+    },
+    "node_modules/icebird": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/icebird/-/icebird-0.3.0.tgz",
+      "integrity": "sha512-NhuhvqVOhzY9wDzolAnc6nYqzWV/HNAF9DTl0Zr8SSr4IOV/ZWkwonu6hiZQJsw6gcQyWIxKx6Inl9Zr0iJsUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hyparquet": "1.13.1",
+        "hyparquet-compressors": "1.1.1",
+        "hyparquet-writer": "0.3.5"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
+    "icebird": "^0.3.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.364.0",
     "next-themes": "^0.4.6",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <title>DuckDB-WASM Query Interface</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,25 +148,57 @@ function App() {
         throw new Error('Schema not found in Iceberg metadata');
       }
       
-      for (let i = 0; i < Math.min(dataEntries.length, 3); i++) { // Limit to first 3 files for performance
-        const dataFile = dataEntries[i].data_file;
-        const fileUrl = dataFile.file_path;
+      if (dataEntries.length > 0) {
+        const dataFile = dataEntries[0].data_file;
+        // Convert s3a:// URLs to https:// URLs for browser access
+        const originalUrl = dataFile.file_path;
+        const fileUrl = originalUrl.replace('s3a://', 'https://s3.amazonaws.com/');
+        console.log(`Converting Iceberg parquet URL: ${originalUrl} -> ${fileUrl}`);
         
-        const tableName = i === 0 ? 'iceberg_data' : `temp_iceberg_${i}`;
-        await conn.query(`
-          CREATE TABLE ${tableName} AS 
-          SELECT * 
-          FROM read_parquet('${fileUrl}')
-        `);
-        
-        if (i > 0) {
+        try {
           await conn.query(`
-            INSERT INTO iceberg_data
-            SELECT * FROM ${tableName}
+            CREATE TABLE iceberg_data AS 
+            SELECT * 
+            FROM read_parquet('${fileUrl}')
           `);
           
-          await conn.query(`DROP TABLE ${tableName}`);
+          for (let i = 1; i < Math.min(dataEntries.length, 3); i++) {
+            const additionalFile = dataEntries[i].data_file;
+            const additionalUrl = additionalFile.file_path.replace('s3a://', 'https://s3.amazonaws.com/');
+            console.log(`Loading additional Iceberg file: ${additionalUrl}`);
+            
+            // Get the schema of the main table to ensure we use matching columns
+            const mainTableSchema = await conn.query(`DESCRIBE iceberg_data`);
+            const mainTableColumns = mainTableSchema.toArray().map(row => row.column_name);
+            
+            const tempTableName = `temp_iceberg_${i}`;
+            await conn.query(`
+              CREATE TABLE ${tempTableName} AS 
+              SELECT * 
+              FROM read_parquet('${additionalUrl}')
+            `);
+            
+            // Get the schema of the temporary table
+            const tempTableSchema = await conn.query(`DESCRIBE ${tempTableName}`);
+            const tempTableColumns = tempTableSchema.toArray().map(row => row.column_name);
+            
+            const commonColumns = mainTableColumns.filter(col => tempTableColumns.includes(col));
+            
+            if (commonColumns.length > 0) {
+              await conn.query(`
+                INSERT INTO iceberg_data (${commonColumns.join(', ')})
+                SELECT ${commonColumns.join(', ')} FROM ${tempTableName}
+              `);
+            }
+            
+            await conn.query(`DROP TABLE ${tempTableName}`);
+          }
+        } catch (err) {
+          console.error(`Failed to load Iceberg data:`, err);
+          throw new Error(`Failed to load Iceberg data: ${err instanceof Error ? err.message : String(err)}`);
         }
+      } else {
+        throw new Error('No data files found in Iceberg manifest');
       }
       
       setIcebergLoaded(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,8 @@ function App() {
   const [icebergLoaded, setIcebergLoaded] = useState<boolean>(false);
   const [icebergVersion, setIcebergVersion] = useState<string | null>(null);
   const [icebergVersions, setIcebergVersions] = useState<string[]>([]);
+  const [manifestFilePath, setManifestFilePath] = useState<string | null>(null);
+  const [parquetFilePaths, setParquetFilePaths] = useState<{original: string, converted: string}[]>([]);
 
   const csvExampleQueries = [
     'SELECT * FROM iris LIMIT 10;',
@@ -122,6 +124,9 @@ function App() {
       const versions = await icebergListVersions({ tableUrl: ICEBERG_TABLE_URL });
       setIcebergVersions(versions);
       
+      const manifestPath = `${ICEBERG_TABLE_URL}/${metadataFileName || (await icebergLatestVersion({ tableUrl: ICEBERG_TABLE_URL })) + '.metadata.json'}`;
+      setManifestFilePath(manifestPath);
+      
       const metadata = await icebergMetadata({ 
         tableUrl: ICEBERG_TABLE_URL,
         metadataFileName
@@ -150,11 +155,15 @@ function App() {
         throw new Error('Schema not found in Iceberg metadata');
       }
       
+      const paths: {original: string, converted: string}[] = [];
+      
       if (dataEntries.length > 0) {
+        
         const dataFile = dataEntries[0].data_file;
         // Convert s3a:// URLs to https:// URLs for browser access
         const originalUrl = dataFile.file_path;
         const fileUrl = originalUrl.replace('s3a://', 'https://s3.amazonaws.com/');
+        paths.push({ original: originalUrl, converted: fileUrl });
         console.log(`Converting Iceberg parquet URL: ${originalUrl} -> ${fileUrl}`);
         
         try {
@@ -167,6 +176,7 @@ function App() {
           for (let i = 1; i < Math.min(dataEntries.length, 3); i++) {
             const additionalFile = dataEntries[i].data_file;
             const additionalUrl = additionalFile.file_path.replace('s3a://', 'https://s3.amazonaws.com/');
+            paths.push({ original: additionalFile.file_path, converted: additionalUrl });
             console.log(`Loading additional Iceberg file: ${additionalUrl}`);
             
             // Get the schema of the main table to ensure we use matching columns
@@ -202,6 +212,8 @@ function App() {
       } else {
         throw new Error('No data files found in Iceberg manifest');
       }
+      
+      setParquetFilePaths(paths);
       
       setIcebergLoaded(true);
       setStatus(`Iceberg data loaded successfully (version ${currentVersion}). Ready to query!`);
@@ -451,6 +463,40 @@ function App() {
                   <Loader2 className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
                   Check for Updates
                 </Button>
+                
+                {/* Display Iceberg File Paths */}
+                {icebergLoaded && (
+                  <div className="mt-4 border border-gray-200 rounded-md p-3 bg-gray-50">
+                    <p className="text-xs font-medium mb-2">Iceberg File Paths:</p>
+                    
+                    {manifestFilePath && (
+                      <div className="mb-2">
+                        <p className="text-xs font-semibold">Manifest File:</p>
+                        <p className="text-xs font-mono break-all bg-white p-1 rounded border border-gray-200">
+                          {manifestFilePath}
+                        </p>
+                      </div>
+                    )}
+                    
+                    {parquetFilePaths.length > 0 && (
+                      <div>
+                        <p className="text-xs font-semibold">Parquet Data Files:</p>
+                        <div className="max-h-40 overflow-y-auto">
+                          {parquetFilePaths.map((path, index) => (
+                            <div key={index} className="mb-1 text-xs">
+                              <p className="font-mono break-all bg-white p-1 rounded border border-gray-200">
+                                <span className="font-semibold">Original:</span> {path.original}
+                              </p>
+                              <p className="font-mono break-all bg-white p-1 rounded border border-gray-200 mt-1">
+                                <span className="font-semibold">Converted:</span> {path.converted}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const DUCKDB_BUNDLES = {
 
 const CSV_URL = 'https://raw.githubusercontent.com/plotly/datasets/master/iris.csv';
 const PARQUET_FILE_PATH = '/data/iris.parquet';
+const ICEBERG_TABLE_URL = 'https://s3.amazonaws.com/hyperparam-iceberg/spark/bunnies'; // Public demo Iceberg table
 
 function App() {
   const [db, setDb] = useState<duckdb.AsyncDuckDB | null>(null);
@@ -29,8 +30,11 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string>('Initializing DuckDB...');
   const [showExamples, setShowExamples] = useState<boolean>(false);
-  const [dataSource, setDataSource] = useState<'csv' | 'parquet'>('csv');
+  const [dataSource, setDataSource] = useState<'csv' | 'parquet' | 'iceberg'>('csv');
   const [parquetLoaded, setParquetLoaded] = useState<boolean>(false);
+  const [icebergLoaded, setIcebergLoaded] = useState<boolean>(false);
+  const [icebergVersion, setIcebergVersion] = useState<string | null>(null);
+  const [icebergVersions, setIcebergVersions] = useState<string[]>([]);
 
   const csvExampleQueries = [
     'SELECT * FROM iris LIMIT 10;',
@@ -46,6 +50,14 @@ function App() {
     'SELECT AVG(SepalLength) as AvgSepalLength, AVG(SepalWidth) as AvgSepalWidth, Name FROM iris_parquet GROUP BY Name;',
     'SELECT * FROM iris_parquet WHERE PetalLength > 5.0;',
     'SELECT * FROM iris_parquet ORDER BY SepalLength DESC LIMIT 5;'
+  ];
+  
+  const icebergExampleQueries = [
+    'SELECT * FROM iceberg_data LIMIT 10;',
+    'SELECT count(*) FROM iceberg_data;',
+    'SELECT * FROM iceberg_data ORDER BY id LIMIT 5;',
+    'SELECT category, COUNT(*) as Count FROM iceberg_data GROUP BY category;',
+    'SELECT AVG(value) as AvgValue FROM iceberg_data;'
   ];
 
   const loadParquetData = async () => {
@@ -82,6 +94,124 @@ function App() {
       setStatus('Error loading parquet data');
       throw err; // Re-throw the error to ensure no fallback logic is used
     } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadIcebergData = async (version?: string) => {
+    if (!conn || !db) {
+      setError('Database connection not initialized');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    
+    try {
+      setStatus('Loading Iceberg data...');
+      
+      await conn.query(`INSTALL parquet; LOAD parquet;`);
+      
+      const { icebergMetadata, icebergLatestVersion, icebergListVersions } = await import('icebird');
+      
+      const metadataFileName = version ? `${version}.metadata.json` : undefined;
+      
+      // Get all available versions of the Iceberg table
+      const versions = await icebergListVersions({ tableUrl: ICEBERG_TABLE_URL });
+      setIcebergVersions(versions);
+      
+      const metadata = await icebergMetadata({ 
+        tableUrl: ICEBERG_TABLE_URL,
+        metadataFileName
+      });
+      
+      const currentVersion = version || (await icebergLatestVersion({ tableUrl: ICEBERG_TABLE_URL }));
+      setIcebergVersion(currentVersion);
+      
+      const { icebergManifests } = await import('icebird');
+      const manifestList = await icebergManifests(metadata);
+      
+      // Convert manifest entries to array and filter out deleted entries
+      const manifestEntries = Array.from(manifestList.entries());
+      const dataEntries = manifestEntries.flatMap(([_, manifest]) => 
+        manifest.entries.filter((entry: any) => entry.status !== 2)
+      );
+      
+      if (dataEntries.length === 0) {
+        throw new Error('No data files found in Iceberg manifest');
+      }
+      
+      await conn.query(`DROP TABLE IF EXISTS iceberg_data`);
+      
+      const schemaFields = metadata.schemas.find(s => s['schema-id'] === metadata['current-schema-id'])?.fields;
+      if (!schemaFields) {
+        throw new Error('Schema not found in Iceberg metadata');
+      }
+      
+      for (let i = 0; i < Math.min(dataEntries.length, 3); i++) { // Limit to first 3 files for performance
+        const dataFile = dataEntries[i].data_file;
+        const fileUrl = dataFile.file_path;
+        
+        const tableName = i === 0 ? 'iceberg_data' : `temp_iceberg_${i}`;
+        await conn.query(`
+          CREATE TABLE ${tableName} AS 
+          SELECT * 
+          FROM read_parquet('${fileUrl}')
+        `);
+        
+        if (i > 0) {
+          await conn.query(`
+            INSERT INTO iceberg_data
+            SELECT * FROM ${tableName}
+          `);
+          
+          await conn.query(`DROP TABLE ${tableName}`);
+        }
+      }
+      
+      setIcebergLoaded(true);
+      setStatus(`Iceberg data loaded successfully (version ${currentVersion}). Ready to query!`);
+      
+      setQuery('SELECT * FROM iceberg_data LIMIT 10;');
+      setDataSource('iceberg');
+    } catch (err) {
+      console.error('Failed to load Iceberg data', err);
+      setError(`Failed to load Iceberg data: ${err instanceof Error ? err.message : String(err)}`);
+      setStatus('Error loading Iceberg data');
+      throw err; // Re-throw the error to ensure no fallback logic is used
+    } finally {
+      setLoading(false);
+    }
+  };
+  
+  const refreshIcebergData = async () => {
+    if (!conn || !db) {
+      setError('Database connection not initialized');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    
+    try {
+      setStatus('Checking for Iceberg table updates...');
+      
+      const { icebergLatestVersion } = await import('icebird');
+      
+      // Get the latest version of the Iceberg table
+      const latestVersion = await icebergLatestVersion({ tableUrl: ICEBERG_TABLE_URL });
+      
+      if (latestVersion !== icebergVersion) {
+        setStatus(`Found new version: ${latestVersion}. Loading...`);
+        await loadIcebergData(latestVersion);
+      } else {
+        setStatus(`Already at latest version: ${latestVersion}`);
+        setLoading(false);
+      }
+    } catch (err) {
+      console.error('Failed to refresh Iceberg data', err);
+      setError(`Failed to refresh Iceberg data: ${err instanceof Error ? err.message : String(err)}`);
+      setStatus('Error refreshing Iceberg data');
       setLoading(false);
     }
   };
@@ -236,13 +366,69 @@ function App() {
                   </span>
                 ) : 'Parquet Data'}
               </Button>
+              <Button
+                variant={dataSource === 'iceberg' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => {
+                  if (!icebergLoaded) {
+                    loadIcebergData();
+                  } else {
+                    setDataSource('iceberg');
+                    setQuery('SELECT * FROM iceberg_data LIMIT 10;');
+                  }
+                }}
+                className="text-xs"
+                disabled={loading || !conn}
+              >
+                {loading && dataSource !== 'iceberg' && !icebergLoaded ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Loading Iceberg...
+                  </span>
+                ) : 'Iceberg Data'}
+              </Button>
             </div>
+            
+            {dataSource === 'iceberg' && icebergVersions.length > 0 && (
+              <div className="flex flex-col space-y-2 mt-2 mb-4">
+                <p className="text-xs text-gray-600">Iceberg Version:</p>
+                <div className="flex flex-wrap gap-1">
+                  {icebergVersions.map((version) => (
+                    <Button
+                      key={version}
+                      variant={icebergVersion === version ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => loadIcebergData(version)}
+                      className="text-xs"
+                      disabled={loading}
+                    >
+                      {version}
+                    </Button>
+                  ))}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={refreshIcebergData}
+                  className="text-xs flex items-center gap-1"
+                  disabled={loading}
+                >
+                  <Loader2 className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
+                  Check for Updates
+                </Button>
+              </div>
+            )}
 
             {showExamples && (
               <div className="mb-4 p-3 bg-gray-50 rounded-md border border-gray-200">
                 <p className="text-sm font-medium mb-2">Example Queries:</p>
                 <div className="space-y-2">
-                  {(dataSource === 'csv' ? csvExampleQueries : parquetExampleQueries).map((example, index) => (
+                  {(dataSource === 'csv' 
+                    ? csvExampleQueries 
+                    : dataSource === 'parquet' 
+                      ? parquetExampleQueries 
+                      : icebergExampleQueries
+                  ).map((example, index) => (
                     <div 
                       key={index} 
                       className="text-xs font-mono bg-white p-2 rounded cursor-pointer hover:bg-blue-50 border border-gray-200"
@@ -332,6 +518,7 @@ function App() {
                 <ul className="list-disc list-inside ml-2">
                   <li><strong>CSV:</strong> Loaded from a public URL using <code>read_csv_auto</code></li>
                   <li><strong>Parquet:</strong> Loaded from a local file using <code>read_parquet</code></li>
+                  <li><strong>Iceberg:</strong> Parquet files extracted from Iceberg metadata using the <code>icebird</code> library</li>
                 </ul>
                 <p className="mt-2 text-xs text-gray-500">DuckDB-WASM supports multiple file formats including CSV, Parquet, and JSON.</p>
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -436,6 +436,7 @@ function App() {
               </Button>
             </div>
             
+            {/* Iceberg Version Selection */}
             {dataSource === 'iceberg' && icebergVersions.length > 0 && (
               <div className="flex flex-col space-y-2 mt-2 mb-4">
                 <p className="text-xs text-gray-600">Iceberg Version:</p>
@@ -463,38 +464,52 @@ function App() {
                   <Loader2 className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
                   Check for Updates
                 </Button>
+              </div>
+            )}
+            
+            {/* Display Iceberg File Paths - Always visible when Iceberg is selected */}
+            {dataSource === 'iceberg' && (
+              <div className="mt-4 mb-4 border-2 border-blue-300 rounded-md p-4 bg-blue-50 shadow-md">
+                <p className="text-sm font-bold mb-3 text-blue-800">📁 Iceberg File Paths:</p>
                 
-                {/* Display Iceberg File Paths */}
-                {icebergLoaded && (
-                  <div className="mt-4 border border-gray-200 rounded-md p-3 bg-gray-50">
-                    <p className="text-xs font-medium mb-2">Iceberg File Paths:</p>
-                    
-                    {manifestFilePath && (
-                      <div className="mb-2">
-                        <p className="text-xs font-semibold">Manifest File:</p>
-                        <p className="text-xs font-mono break-all bg-white p-1 rounded border border-gray-200">
-                          {manifestFilePath}
-                        </p>
-                      </div>
-                    )}
-                    
-                    {parquetFilePaths.length > 0 && (
-                      <div>
-                        <p className="text-xs font-semibold">Parquet Data Files:</p>
-                        <div className="max-h-40 overflow-y-auto">
-                          {parquetFilePaths.map((path, index) => (
-                            <div key={index} className="mb-1 text-xs">
-                              <p className="font-mono break-all bg-white p-1 rounded border border-gray-200">
-                                <span className="font-semibold">Original:</span> {path.original}
-                              </p>
-                              <p className="font-mono break-all bg-white p-1 rounded border border-gray-200 mt-1">
-                                <span className="font-semibold">Converted:</span> {path.converted}
-                              </p>
-                            </div>
-                          ))}
+                {manifestFilePath ? (
+                  <div className="mb-3">
+                    <p className="text-xs font-semibold text-blue-700">Manifest File:</p>
+                    <p className="text-xs font-mono break-all bg-white p-2 rounded border border-gray-200">
+                      {manifestFilePath}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="mb-3">
+                    <p className="text-xs font-semibold text-blue-700">Manifest File:</p>
+                    <p className="text-xs italic text-gray-500">
+                      {loading ? "Loading manifest file path..." : "No manifest file loaded yet. Click the Iceberg Data button to load."}
+                    </p>
+                  </div>
+                )}
+                
+                {parquetFilePaths.length > 0 ? (
+                  <div>
+                    <p className="text-xs font-semibold text-blue-700">Parquet Data Files:</p>
+                    <div className="max-h-40 overflow-y-auto">
+                      {parquetFilePaths.map((path, index) => (
+                        <div key={index} className="mb-2 text-xs">
+                          <p className="font-mono break-all bg-white p-2 rounded border border-gray-200">
+                            <span className="font-semibold">Original:</span> {path.original}
+                          </p>
+                          <p className="font-mono break-all bg-white p-2 rounded border border-gray-200 mt-1">
+                            <span className="font-semibold">Converted:</span> {path.converted}
+                          </p>
                         </div>
-                      </div>
-                    )}
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div>
+                    <p className="text-xs font-semibold text-blue-700">Parquet Data Files:</p>
+                    <p className="text-xs italic text-gray-500">
+                      {loading ? "Loading parquet file paths..." : "No parquet files loaded yet. Click the Iceberg Data button to load."}
+                    </p>
                   </div>
                 )}
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from './com
 import { Database, Info, Loader2 } from 'lucide-react';
 import './App.css';
 
+const APP_VERSION = '1.1.0-' + Date.now();
+
 const DUCKDB_BUNDLES = {
   mvp: {
     mainModule: '/duckdb/duckdb-mvp.wasm',
@@ -409,15 +411,16 @@ function App() {
                     setQuery('SELECT * FROM iceberg_data LIMIT 10;');
                   }
                 }}
-                className="text-xs"
+                className="text-xs font-bold border-2 border-blue-400 hover:bg-blue-100"
                 disabled={loading || !conn}
+                id="iceberg-data-button"
               >
                 {loading && dataSource !== 'iceberg' && !icebergLoaded ? (
                   <span className="flex items-center gap-2">
                     <Loader2 className="h-3 w-3 animate-spin" />
                     Loading Iceberg...
                   </span>
-                ) : 'Iceberg Data'}
+                ) : '🧊 Iceberg Data'}
               </Button>
             </div>
             
@@ -553,6 +556,7 @@ function App() {
                   <li><strong>Iceberg:</strong> Parquet files extracted from Iceberg metadata using the <code>icebird</code> library</li>
                 </ul>
                 <p className="mt-2 text-xs text-gray-500">DuckDB-WASM supports multiple file formats including CSV, Parquet, and JSON.</p>
+                <p className="mt-2 text-xs text-gray-400">Version: {APP_VERSION}</p>
               </div>
             </div>
           </div>

--- a/src/testIcebergTimeTravel.js
+++ b/src/testIcebergTimeTravel.js
@@ -44,8 +44,9 @@ async function testIcebergTimeTravel() {
       console.log('Schema ID:', metadata['current-schema-id']);
       console.log('Fields:', schema?.fields);
       
-      const snapshot = metadata.snapshots.find(s => s.snapshot_id.toString() === version);
-      console.log('Snapshot:', snapshot);
+      console.log('Snapshots:', metadata.snapshots);
+      const snapshot = metadata.snapshots[metadata.snapshots.length - 1]; // Use latest snapshot
+      console.log('Using snapshot:', snapshot);
       
       const manifestList = await icebergManifests(metadata);
       const manifestEntries = Array.from(manifestList.entries());

--- a/src/testIcebergTimeTravel.js
+++ b/src/testIcebergTimeTravel.js
@@ -1,0 +1,107 @@
+import { icebergMetadata, icebergListVersions, icebergLatestVersion, icebergManifests } from 'icebird';
+
+const ICEBERG_TABLE_URL = 'https://s3.amazonaws.com/hyperparam-iceberg/spark/bunnies';
+
+/**
+ * Test Iceberg time travel functionality by:
+ * 1. Fetching all available versions
+ * 2. Getting metadata for each version
+ * 3. Comparing schema and data files between versions
+ */
+async function testIcebergTimeTravel() {
+  try {
+    console.log('=== ICEBERG TIME TRAVEL TEST ===');
+    console.log('Table URL:', ICEBERG_TABLE_URL);
+    
+    console.log('\nFetching available versions...');
+    const versions = await icebergListVersions({ tableUrl: ICEBERG_TABLE_URL });
+    console.log('Available versions:', versions);
+    
+    if (versions.length < 2) {
+      console.warn('Warning: Need at least 2 versions to test time travel. Only found', versions.length);
+      return;
+    }
+    
+    const latestVersion = await icebergLatestVersion({ tableUrl: ICEBERG_TABLE_URL });
+    console.log('Latest version:', latestVersion);
+    
+    const lastTwoVersions = versions.slice(-2);
+    console.log('\nTesting time travel between versions:', lastTwoVersions);
+    
+    const versionMetadata = [];
+    
+    for (const version of lastTwoVersions) {
+      console.log(`\n=== Version ${version} ===`);
+      
+      const metadata = await icebergMetadata({ 
+        tableUrl: ICEBERG_TABLE_URL,
+        metadataFileName: `${version}.metadata.json` 
+      });
+      
+      versionMetadata.push({ version, metadata });
+      
+      const schema = metadata.schemas.find(s => s['schema-id'] === metadata['current-schema-id']);
+      console.log('Schema ID:', metadata['current-schema-id']);
+      console.log('Fields:', schema?.fields);
+      
+      const snapshot = metadata.snapshots.find(s => s.snapshot_id.toString() === version);
+      console.log('Snapshot:', snapshot);
+      
+      const manifestList = await icebergManifests(metadata);
+      const manifestEntries = Array.from(manifestList.entries());
+      const dataFiles = manifestEntries.flatMap(([_, manifest]) => 
+        manifest.entries.filter((entry) => entry.status !== 2)
+      );
+      
+      console.log('Data files count:', dataFiles.length);
+      if (dataFiles.length > 0) {
+        console.log('Sample data file:', dataFiles[0].data_file);
+      }
+    }
+    
+    if (versionMetadata.length === 2) {
+      const [olderVersion, newerVersion] = versionMetadata;
+      console.log('\n=== Version Comparison ===');
+      
+      const olderSchema = olderVersion.metadata.schemas.find(
+        s => s['schema-id'] === olderVersion.metadata['current-schema-id']
+      );
+      const newerSchema = newerVersion.metadata.schemas.find(
+        s => s['schema-id'] === newerVersion.metadata['current-schema-id']
+      );
+      
+      console.log('Schema changed:', 
+        JSON.stringify(olderSchema) !== JSON.stringify(newerSchema));
+      
+      console.log('Older snapshot ID:', olderVersion.version);
+      console.log('Newer snapshot ID:', newerVersion.version);
+      
+      const olderManifestList = await icebergManifests(olderVersion.metadata);
+      const newerManifestList = await icebergManifests(newerVersion.metadata);
+      
+      const olderManifestEntries = Array.from(olderManifestList.entries());
+      const newerManifestEntries = Array.from(newerManifestList.entries());
+      
+      const olderDataFiles = olderManifestEntries.flatMap(([_, manifest]) => 
+        manifest.entries.filter((entry) => entry.status !== 2)
+      );
+      const newerDataFiles = newerManifestEntries.flatMap(([_, manifest]) => 
+        manifest.entries.filter((entry) => entry.status !== 2)
+      );
+      
+      console.log('Older version data files count:', olderDataFiles.length);
+      console.log('Newer version data files count:', newerDataFiles.length);
+      console.log('Data files changed:', olderDataFiles.length !== newerDataFiles.length);
+    }
+    
+    console.log('\nTime travel test completed successfully!');
+  } catch (error) {
+    console.error('Error during time travel test:', error);
+    throw error; // Re-throw to ensure no fallback logic is used
+  }
+}
+
+testIcebergTimeTravel().catch(error => {
+  console.error('Test failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
# Add Iceberg File Support with Time Travel Functionality

This PR adds support for querying Iceberg tables using DuckDB-WASM. The implementation uses the icebird JavaScript library to read Iceberg metadata and extract parquet file locations, then uses DuckDB-WASM to query those parquet files.

## Features

- **Real Iceberg Data**: Loads and queries real Iceberg tables from public S3 buckets
- **Time Travel**: Supports selecting different versions of Iceberg tables through the UI
- **Update Detection**: Can check for and load updates to Iceberg tables
- **No Mocks or Fallbacks**: Uses real data and throws errors rather than falling back to alternative logic

## Implementation Details

- Added Iceberg data source button in the UI
- Implemented version selection controls for time travel
- Added "Check for Updates" functionality
- Created test script for Iceberg time travel
- Fixed URL conversion for browser access (s3a:// to https://)
- Implemented proper column mapping for multiple parquet files

## Testing

The implementation has been tested locally with:
- Loading different versions of Iceberg data
- Executing SQL queries on Iceberg data
- Checking for updates to Iceberg tables

Link to Devin run: https://app.devin.ai/sessions/5b973217e0a74329b6402b732dc19ae6
Requested by: Neema Raphael